### PR TITLE
Add enum variable for insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ If anyone has any objections, please let me know.
 	
 	func main() {
 	    buffer := cache.New()
-	    buffer.ReplaceOrInsert(cache.Int(1))
-	    buffer.ReplaceOrInsert(cache.Int(2))
-	    buffer.ReplaceOrInsert(cache.Int(3))
-	    buffer.ReplaceOrInsert(cache.Int(4))
+	    buffer.Add(cache.Int(1), cache.MOD_NOREPLACE)
+	    buffer.Add(cache.Int(2), cache.MOD_NOREPLACE)
+	    buffer.Add(cache.Int(3), cache.MOD_NOREPLACE)
+	    buffer.Add(cache.Int(4), cache.MOD_NOREPLACE)
 	    buffer.DeleteMin()
 	    buffer.Delete(cache.Int(4))
 	    buffer.AscendGreaterOrEqual(buffer.Min(), Print)
@@ -77,11 +77,11 @@ If anyone has any objections, please let me know.
 		buffer := cache.New()
 		var1 := Var{
 			Expiry: time.Now().Add(time.Second * 10),
-			ID:     "var5",
+			ID:     "var1",
 		}
 		var2 := Var{
 			Expiry: time.Now().Add(time.Second * 20),
-			ID:     "var4",
+			ID:     "var2",
 		}
 		var3 := Var{
 			Expiry: time.Now().Add(time.Second * 30),
@@ -89,18 +89,18 @@ If anyone has any objections, please let me know.
 		}
 		var4 := Var{
 			Expiry: time.Now().Add(time.Second * 40),
-			ID:     "var2",
+			ID:     "var4",
 		}
 		var5 := Var{
 			Expiry: time.Now().Add(time.Second * 50),
-			ID:     "var1",
+			ID:     "var5",
 		}
 	
-		buffer.ReplaceOrInsert(var1)
-		buffer.ReplaceOrInsert(var2)
-		buffer.ReplaceOrInsert(var3)
-		buffer.ReplaceOrInsert(var4)
-		buffer.ReplaceOrInsert(var5)
+		buffer.Add(var1, cache.MOD_REPLACE)
+		buffer.Add(var2, cache.MOD_REPLACE)
+		buffer.Add(var3, cache.MOD_REPLACE)
+		buffer.Add(var4, cache.MOD_REPLACE)
+		buffer.Add(var5, cache.MOD_REPLACE)
 	
 		go func() {
 			for {

--- a/example/example_int.go
+++ b/example/example_int.go
@@ -16,10 +16,10 @@ func Print(item cache.Item, buffer *cache.LLRB) bool {
 
 func main() {
 	buffer := cache.New()
-	buffer.ReplaceOrInsert(cache.Int(1))
-	buffer.ReplaceOrInsert(cache.Int(2))
-	buffer.ReplaceOrInsert(cache.Int(3))
-	buffer.ReplaceOrInsert(cache.Int(4))
+	buffer.Add(cache.Int(1), cache.MOD_NOREPLACE)
+	buffer.Add(cache.Int(2), cache.MOD_NOREPLACE)
+	buffer.Add(cache.Int(3), cache.MOD_NOREPLACE)
+	buffer.Add(cache.Int(4), cache.MOD_NOREPLACE)
 	buffer.DeleteMin()
 	buffer.Delete(cache.Int(4))
 	buffer.AscendGreaterOrEqual(buffer.Min(), Print)

--- a/example/example_struct.go
+++ b/example/example_struct.go
@@ -33,11 +33,11 @@ func main() {
 	buffer := cache.New()
 	var1 := Var{
 		Expiry: time.Now().Add(time.Second * 10),
-		ID:     "var5",
+		ID:     "var1",
 	}
 	var2 := Var{
 		Expiry: time.Now().Add(time.Second * 20),
-		ID:     "var4",
+		ID:     "var2",
 	}
 	var3 := Var{
 		Expiry: time.Now().Add(time.Second * 30),
@@ -45,18 +45,18 @@ func main() {
 	}
 	var4 := Var{
 		Expiry: time.Now().Add(time.Second * 40),
-		ID:     "var2",
+		ID:     "var4",
 	}
 	var5 := Var{
 		Expiry: time.Now().Add(time.Second * 50),
-		ID:     "var1",
+		ID:     "var5",
 	}
 
-	buffer.ReplaceOrInsert(var1)
-	buffer.ReplaceOrInsert(var2)
-	buffer.ReplaceOrInsert(var3)
-	buffer.ReplaceOrInsert(var4)
-	buffer.ReplaceOrInsert(var5)
+	buffer.Add(var1, cache.MOD_REPLACE)
+	buffer.Add(var2, cache.MOD_REPLACE)
+	buffer.Add(var3, cache.MOD_REPLACE)
+	buffer.Add(var4, cache.MOD_REPLACE)
+	buffer.Add(var5, cache.MOD_REPLACE)
 
 	go func() {
 		for {

--- a/llrb.go
+++ b/llrb.go
@@ -16,6 +16,11 @@
 //
 package cache
 
+const (
+	MOD_REPLACE   = 0
+	MOD_NOREPLACE = 1
+)
+
 // Tree is a Left-Leaning Red-Black (LLRB) implementation of 2-3 trees
 type LLRB struct {
 	count int
@@ -152,8 +157,8 @@ func (t *LLRB) InsertNoReplaceBulk(items ...Item) {
 // order, which means FIFO.
 // If @repeat is false, when an existing element has the same order,
 // the former will be replaced by the latter.
-func (t *LLRB) Add(item Item, repeat bool) Item {
-	if repeat {
+func (t *LLRB) Add(item Item, mod uint) Item {
+	if mod == MOD_NOREPLACE {
 		return t.InsertNoReplace(item)
 	}
 	return t.ReplaceOrInsert(item)


### PR DESCRIPTION
Use `MOD_REPLACE` and `MOD_NOREPLACE` to distinguish the insert action.

Update the Readme and example also.

Signed-off-by: Hu Keping <hukeping@huawei.com>